### PR TITLE
allow to configure custom dns server in config file

### DIFF
--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -1,5 +1,9 @@
 use serde::{Serialize, Deserialize};
-use trust_dns_resolver::config::LookupIpStrategy;
+use trust_dns_resolver::config::{ResolverConfig,NameServerConfig,LookupIpStrategy,Protocol};
+use std::net::IpAddr;
+use crate::error::addr::{Result, AddrError};
+use crate::utils::{must};
+use std::net::SocketAddr;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -29,5 +33,84 @@ impl From<DnsMode> for LookupIpStrategy {
             DnsMode::Ipv4ThenIpv6 => LookupIpStrategy::Ipv4thenIpv6,
             DnsMode::Ipv6ThenIpv4 => LookupIpStrategy::Ipv6thenIpv4,
         }
+    }
+}
+
+fn default_dns_address() -> String {
+    String::from("8.8.8.8")
+}
+
+fn default_dns_port() -> u16 {
+    53
+}
+
+fn default_dns_protocol() -> String {
+    String::from("udp")
+}
+
+fn default_trust_nx_responses() -> bool {
+    true
+}
+
+fn default_dns_tls_servername() -> Option<String> {
+    None
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct DnsServerConfig {
+    #[serde(default ="default_dns_address")]
+    pub address: String,
+
+    #[serde(default = "default_dns_port")]
+    pub port: u16,
+
+    #[serde(default = "default_dns_protocol")]
+    pub protocol: String,
+
+    #[serde(default = "default_trust_nx_responses")]
+    pub trust_nx_responses: bool,
+
+    #[serde(default = "default_dns_tls_servername")]
+    pub tls_servername: Option<String>,
+}
+
+pub fn parse_ip_addr(
+    addr: &str
+) -> Result<(IpAddr, bool)> {
+    if let Ok(sockaddr) = addr.parse::<IpAddr>() {
+        return Ok((sockaddr, sockaddr.is_ipv6()));
+    };
+    Err(AddrError::Invalid(addr.to_string()))
+}
+
+impl DnsServerConfig {
+    pub fn convert(&self) -> NameServerConfig {
+        let (sockaddr, _) = must!(parse_ip_addr(&(self.address)));
+        let protocol = match &(self.protocol)[..] {
+            "tcp" => Protocol::Tcp,
+            #[cfg(feature = "dns-over-tls")]
+            "tls" => Protocol::Tls,
+            #[cfg(feature = "dns-over-https")]
+            "https" => Protocol::Https,
+            #[cfg(feature = "mdns")]
+            "mdns" => Protocol::Mdns,
+            _ => Protocol::Udp,
+            };
+            NameServerConfig {
+            socket_addr: SocketAddr::new(sockaddr, self.port),
+            protocol: protocol,
+            tls_dns_name: self.tls_servername.clone(),
+            trust_nx_responses: self.trust_nx_responses,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_config: None,
+        }
+    }
+}
+
+impl From<DnsServerConfig> for ResolverConfig {
+    fn from(dns_server: DnsServerConfig) -> Self {
+        let mut resolver_config = ResolverConfig::new();
+        resolver_config.add_name_server(dns_server.convert());
+        resolver_config
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ pub mod tls;
 pub mod trans;
 // re-export
 pub use dns::DnsMode;
+pub use dns::DnsServerConfig;
 pub use net::NetConfig;
 pub use tls::TLSConfig;
 pub use trans::TransportConfig;
@@ -21,6 +22,7 @@ pub use ep::{EndpointConfig, EpHalfConfig, MaybeHalfConfig};
 pub struct GlobalConfig {
     #[serde(default)]
     pub dns_mode: DnsMode,
+    pub dns_servers: Vec<DnsServerConfig>,
     pub endpoints: Vec<EndpointConfig>,
 }
 

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -1,26 +1,38 @@
 use std::io::{Result, Error, ErrorKind};
 use std::net::IpAddr;
 
+use crate::config::dns::DnsServerConfig;
+
 use futures::executor;
 use trust_dns_resolver::TokioAsyncResolver;
 use trust_dns_resolver::config::{ResolverConfig, ResolverOpts, LookupIpStrategy};
 use lazy_static::lazy_static;
 
 static mut RESOLVE_STRATEGY: LookupIpStrategy = LookupIpStrategy::Ipv4thenIpv6;
+static mut DNS_SERVERS: Vec<DnsServerConfig> = vec![];
 
 lazy_static! {
-    static ref DNS: TokioAsyncResolver = TokioAsyncResolver::tokio(
-        ResolverConfig::default(),
+    static ref DNS: TokioAsyncResolver = {
+        let mut temp_resolver_config : ResolverConfig = ResolverConfig::new();
+        unsafe { 
+            for dns_server in &DNS_SERVERS {
+                temp_resolver_config.add_name_server(dns_server.convert());
+            }
+        }
+        TokioAsyncResolver::tokio(
+        temp_resolver_config,
         ResolverOpts {
             ip_strategy: unsafe { RESOLVE_STRATEGY },
             ..Default::default()
         }
     )
-    .unwrap();
+    .unwrap()};
 }
 
-pub fn init_resolver(strategy: LookupIpStrategy) {
+pub fn init_resolver(strategy: LookupIpStrategy,dns_server_configs: Vec<DnsServerConfig>) {
     unsafe { RESOLVE_STRATEGY = strategy };
+    
+    unsafe { DNS_SERVERS = dns_server_configs};
     lazy_static::initialize(&DNS);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
 fn start_from_config(c: String) {
     let config = GlobalConfig::from_config_file(&c);
-    dns::init_resolver(config.dns_mode.into());
+    dns::init_resolver(config.dns_mode.into(),config.dns_servers);
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -8,7 +8,7 @@ use crate::config::{EndpointConfig, EpHalfConfig};
 
 mod net;
 mod transport;
-mod common;
+pub mod common;
 
 #[cfg(target_os = "linux")]
 pub fn meet_zero_copy(listen: &EpHalfConfig, remote: &EpHalfConfig) -> bool {


### PR DESCRIPTION
{
    "dns_mode": "ipv4_then_ipv6",
    **"dns_servers": [{
            "address": "1.1.1.1",
            "port": 53,
            "trust_nx_responses": true,
            "protocol": "udp",
            "tls_servername": "127.0.0.1"
        }
    ],**
    "endpoints": [{
            "listen": {
                "addr": "10.2.4.3:52443",
                "net": "tcp",
                "trans": {
                    "proto": "ws",
                    "path": "/ws"
                }
            },
            "remote": {
                "addr": "myserver.example.com:443",
                "net": "tcp",
                "trans": {
                    "proto": "ws",
                    "path": "/ws"
                },
                "tls": {
                    "sni": "api.example.com",
                    "skip_verify": false,
                    "enable_early_data": true,
                    "roots": "firefox"
                }
            }
        }
    ]
}