### PR TITLE
add new features: allow user to customize dns servers

### DIFF
--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Deserialize};
 use trust_dns_resolver::config::LookupIpStrategy;
-use trust_dns_resolver::config::{NameServerConfig,Protocol};
+use trust_dns_resolver::config::{NameServerConfig, Protocol};
 use std::net::ToSocketAddrs;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -36,27 +36,34 @@ impl From<DnsMode> for LookupIpStrategy {
 
 // default values
 const fn def_true() -> bool { true }
-fn default_protocol() -> String {String::from("udp")}
-    
+fn default_protocol() -> String { String::from("udp") }
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct DnsServerNode {
-    
     addr: String,
-    
+
     #[serde(default = "default_protocol")]
     protocol: String,
-    
+
     #[serde(default = "def_true")]
-    trust_nx_responses: bool
+    trust_nx_responses: bool,
 }
 
 impl From<DnsServerNode> for NameServerConfig {
     fn from(dns_server_node: DnsServerNode) -> Self {
-        let dns_server_socket = dns_server_node.addr.to_socket_addrs().unwrap().next().unwrap();
+        let dns_server_socket = dns_server_node
+            .addr
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
 
         let str_protocol = dns_server_node.protocol.as_str();
-        let dest_protocol = match str_protocol {"tcp" => Protocol::Tcp , _ => Protocol::Udp,};
+        let dest_protocol = match str_protocol {
+            "tcp" => Protocol::Tcp,
+            _ => Protocol::Udp,
+        };
         let dest_trust_nx_responses = dns_server_node.trust_nx_responses;
         NameServerConfig {
             socket_addr: dns_server_socket,

--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Deserialize};
 use trust_dns_resolver::config::LookupIpStrategy;
 use trust_dns_resolver::config::{NameServerConfig,Protocol};
-use std::net::{SocketAddr,IpAddr};
+use std::net::{SocketAddr,ToSocketAddrs};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,8 +35,7 @@ impl From<DnsMode> for LookupIpStrategy {
 }
 
 // default values
-fn def_true() -> bool { true }
-fn default_port() -> u16 { 53 }
+const fn def_true() -> bool { true }
 fn default_protocol() -> String {String::from("udp")}
     
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,9 +43,6 @@ fn default_protocol() -> String {String::from("udp")}
 pub struct DnsServerNode {
     
     addr: String,
-    
-    #[serde(default = "default_port")]
-    port: u16,
     
     #[serde(default = "default_protocol")]
     protocol: String,
@@ -57,7 +53,8 @@ pub struct DnsServerNode {
 
 impl From<DnsServerNode> for NameServerConfig {
     fn from(dns_server_node: DnsServerNode) -> Self {
-        let dns_server_socket = SocketAddr::new(dns_server_node.addr.parse::<IpAddr>().unwrap(), dns_server_node.port);
+        let dns_server_socket = dns_server_node.addr.to_socket_addrs().unwrap().next().unwrap();
+
         let str_protocol = dns_server_node.protocol.as_str();
         let dest_protocol = match str_protocol {"tcp" => Protocol::Tcp , _ => Protocol::Udp,};
         let dest_trust_nx_responses = dns_server_node.trust_nx_responses;

--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Deserialize};
 use trust_dns_resolver::config::LookupIpStrategy;
 use trust_dns_resolver::config::{NameServerConfig,Protocol};
-use std::net::{SocketAddr,ToSocketAddrs};
+use std::net::ToSocketAddrs;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -63,8 +63,6 @@ impl From<DnsServerNode> for NameServerConfig {
             protocol: dest_protocol,
             tls_dns_name: None,
             trust_nx_responses: dest_trust_nx_responses,
-            #[cfg(feature = "dns-over-rustls")]
-            tls_config: None,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,7 +12,7 @@ pub mod tls;
 pub mod trans;
 
 // re-export
-pub use self::dns::{DnsMode,DnsServerNode};
+pub use self::dns::{DnsMode, DnsServerNode};
 pub use net::NetConfig;
 pub use tls::TLSConfig;
 pub use trans::TransportConfig;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,8 +10,9 @@ pub mod ep;
 pub mod net;
 pub mod tls;
 pub mod trans;
+
 // re-export
-pub use dns::DnsMode;
+pub use self::dns::{DnsMode,DnsServerNode};
 pub use net::NetConfig;
 pub use tls::TLSConfig;
 pub use trans::TransportConfig;
@@ -22,6 +23,7 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub dns_mode: DnsMode,
     pub endpoints: Vec<EndpointConfig>,
+    pub dns_servers: Vec<DnsServerNode>,
 }
 
 impl GlobalConfig {

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -33,7 +33,7 @@ lazy_static! {
 pub fn init_resolver(strategy: LookupIpStrategy,dns_servers: Vec<DnsServerNode>) {
     
     let mut resolver_config = ResolverConfig::new();
-    if dns_servers.len()==0 {
+    if dns_servers.is_empty() {
         resolver_config = ResolverConfig::cloudflare();
     }else{
         for dns_server in dns_servers.into_iter() {

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -1,26 +1,50 @@
 use std::io::{Result, Error, ErrorKind};
-use std::net::IpAddr;
+use std::net::{IpAddr};
 
 use futures::executor;
 use trust_dns_resolver::TokioAsyncResolver;
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts, LookupIpStrategy};
+use trust_dns_resolver::config::{ResolverConfig, ResolverOpts, LookupIpStrategy,NameServerConfig};
 use lazy_static::lazy_static;
+use log::{debug};
+
+use super::config::dns::{DnsServerNode};
+
 
 static mut RESOLVE_STRATEGY: LookupIpStrategy = LookupIpStrategy::Ipv4thenIpv6;
+static mut RESOLVER_CONFIGS: Vec<ResolverConfig> = vec![];
 
 lazy_static! {
-    static ref DNS: TokioAsyncResolver = TokioAsyncResolver::tokio(
-        ResolverConfig::default(),
-        ResolverOpts {
-            ip_strategy: unsafe { RESOLVE_STRATEGY },
-            ..Default::default()
-        }
-    )
-    .unwrap();
+    static ref DNS: TokioAsyncResolver = {
+        let resolver_config = {
+            unsafe{
+                RESOLVER_CONFIGS.pop().unwrap()
+            }
+        };
+        TokioAsyncResolver::tokio(
+            resolver_config,
+            ResolverOpts {
+                ip_strategy: unsafe { RESOLVE_STRATEGY },
+                ..Default::default()
+            }
+        )
+    }.unwrap();
 }
 
-pub fn init_resolver(strategy: LookupIpStrategy) {
-    unsafe { RESOLVE_STRATEGY = strategy };
+pub fn init_resolver(strategy: LookupIpStrategy,dns_servers: Vec<DnsServerNode>) {
+    
+    let mut resolver_config = ResolverConfig::new();
+    if dns_servers.len()==0 {
+        resolver_config = ResolverConfig::cloudflare();
+    }else{
+        for dns_server in dns_servers.into_iter() {
+            debug!("load next dns_server");
+            resolver_config.add_name_server(NameServerConfig::from(dns_server));
+        }
+    }
+    unsafe { 
+        RESOLVE_STRATEGY = strategy;
+        RESOLVER_CONFIGS.push(resolver_config);
+    };
     lazy_static::initialize(&DNS);
 }
 

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -3,45 +3,45 @@ use std::net::{IpAddr};
 
 use futures::executor;
 use trust_dns_resolver::TokioAsyncResolver;
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts, LookupIpStrategy,NameServerConfig};
+use trust_dns_resolver::config::{
+    ResolverConfig, ResolverOpts, LookupIpStrategy, NameServerConfig,
+};
 use lazy_static::lazy_static;
 use log::{debug};
 
 use super::config::dns::{DnsServerNode};
-
 
 static mut RESOLVE_STRATEGY: LookupIpStrategy = LookupIpStrategy::Ipv4thenIpv6;
 static mut RESOLVER_CONFIGS: Vec<ResolverConfig> = vec![];
 
 lazy_static! {
     static ref DNS: TokioAsyncResolver = {
-        let resolver_config = {
-            unsafe{
-                RESOLVER_CONFIGS.pop().unwrap()
-            }
-        };
+        let resolver_config = { unsafe { RESOLVER_CONFIGS.pop().unwrap() } };
         TokioAsyncResolver::tokio(
             resolver_config,
             ResolverOpts {
                 ip_strategy: unsafe { RESOLVE_STRATEGY },
                 ..Default::default()
-            }
+            },
         )
-    }.unwrap();
+    }
+    .unwrap();
 }
 
-pub fn init_resolver(strategy: LookupIpStrategy,dns_servers: Vec<DnsServerNode>) {
-    
+pub fn init_resolver(
+    strategy: LookupIpStrategy,
+    dns_servers: Vec<DnsServerNode>,
+) {
     let mut resolver_config = ResolverConfig::new();
     if dns_servers.is_empty() {
         resolver_config = ResolverConfig::cloudflare();
-    }else{
+    } else {
         for dns_server in dns_servers.into_iter() {
             debug!("load next dns_server");
             resolver_config.add_name_server(NameServerConfig::from(dns_server));
         }
     }
-    unsafe { 
+    unsafe {
         RESOLVE_STRATEGY = strategy;
         RESOLVER_CONFIGS.push(resolver_config);
     };

--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -16,7 +16,7 @@ where
         if n == 0 {
             break;
         };
-        w.write(&buf[..n]).await?;
+        let _ = w.write(&buf[..n]).await?;
     }
     w.shutdown().await?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
 fn start_from_config(c: String) {
     let config = GlobalConfig::from_config_file(&c);
-    dns::init_resolver(config.dns_mode.into());
+    dns::init_resolver(config.dns_mode.into(),config.dns_servers);
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
 fn start_from_config(c: String) {
     let config = GlobalConfig::from_config_file(&c);
-    dns::init_resolver(config.dns_mode.into(),config.dns_servers);
+    dns::init_resolver(config.dns_mode.into(), config.dns_servers);
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
this pull request add new features which allow user to customize dns servers

config example : 
{
    "dns_mode": "ipv6_then_ipv4",
    **"dns_servers": [{
            "addr": "114.114.114.114",
            "port": 53,
            "protocol": "udp",
            "trust_nx_responses": true
        },{
            "addr": "223.5.5.5",
            "port": 53,
            "protocol": "udp",
            "trust_nx_responses": true
        },{
            "addr": "202.101.172.35",
            "port": 53,
            "protocol": "udp",
            "trust_nx_responses": true
        }
    ],**
    "endpoints": [{
            "listen": {
                "addr": "0.0.0.0:80",
                "net": "tcp"
            },
            "remote": {
                "addr": "iot.fotile.com:80",
                "net": "tcp"
            }
        }
    ]
}

**If no dns server is specified, the default dns configuration is used**

